### PR TITLE
Leveraging cached groups to make APIs more efficient

### DIFF
--- a/apps/api/src/app/common/utils.ts
+++ b/apps/api/src/app/common/utils.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns the string of a JSON, even if it contains bigint types.
+ * @param obj JavaScript object.
+ * @returns JSON string
+ */
+export function stringifyJSON(obj: Record<string, unknown>): string {
+    return JSON.stringify(obj, (_, v) =>
+        typeof v === "bigint" ? v.toString() : v
+    )
+}

--- a/apps/api/src/app/groups/dto/add-member.dto.ts
+++ b/apps/api/src/app/groups/dto/add-member.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, Length } from "class-validator"
+
+export class AddMemberDto {
+    @IsString()
+    @Length(8)
+    readonly inviteCode: string
+}

--- a/apps/api/src/app/groups/dto/update-group.dto.ts
+++ b/apps/api/src/app/groups/dto/update-group.dto.ts
@@ -6,6 +6,7 @@ import {
     IsOptional,
     MinLength
 } from "class-validator"
+
 export class UpdateGroupDto {
     @IsOptional()
     @IsString()

--- a/apps/api/src/app/groups/entities/group.entity.ts
+++ b/apps/api/src/app/groups/entities/group.entity.ts
@@ -13,10 +13,6 @@ export class Group {
 
     @Column()
     @Index({ unique: true })
-    index: number
-
-    @Column()
-    @Index({ unique: true })
     name: string
 
     @Column()

--- a/apps/api/src/app/groups/groups.service.spec.ts
+++ b/apps/api/src/app/groups/groups.service.spec.ts
@@ -47,7 +47,7 @@ describe("GroupsService", () => {
         })
 
         it("Should not create two groups with the same name", async () => {
-            const result = groupsService.createGroup(
+            const fun = groupsService.createGroup(
                 {
                     name: "Group1",
                     description: "This is a description",
@@ -56,7 +56,7 @@ describe("GroupsService", () => {
                 "admin"
             )
 
-            await expect(result).rejects.toThrow("UNIQUE constraint failed")
+            await expect(fun).rejects.toThrow("UNIQUE constraint failed")
         })
     })
 
@@ -74,7 +74,7 @@ describe("GroupsService", () => {
         })
 
         it("Should not update a group if the admin is the wrong one", async () => {
-            const result = groupsService.updateGroup(
+            const fun = groupsService.updateGroup(
                 {
                     description: "This is a new description"
                 },
@@ -82,7 +82,7 @@ describe("GroupsService", () => {
                 "wrong-admin"
             )
 
-            await expect(result).rejects.toThrow("No permissions")
+            await expect(fun).rejects.toThrow("No permissions")
         })
     })
 
@@ -112,9 +112,9 @@ describe("GroupsService", () => {
         })
 
         it("Should throw 404 error about not exist group", async () => {
-            const result = groupsService.getGroup("Group2")
+            const fun = groupsService.getGroup("Group2")
 
-            await expect(result).rejects.toThrow("not found")
+            await expect(fun).rejects.toThrow("not found")
         })
     })
 
@@ -130,42 +130,42 @@ describe("GroupsService", () => {
 
         it("Should add a member to an existing group", async () => {
             const { members } = await groupsService.addMember(
+                { inviteCode: invite.code },
                 "Group1",
-                "123123",
-                invite.code
+                "123123"
             )
 
             expect(members).toHaveLength(1)
         })
 
         it("Should not add any member if they already exist", async () => {
-            const result = groupsService.addMember(
+            const fun = groupsService.addMember(
+                { inviteCode: invite.code },
                 "Group1",
-                "123123",
-                invite.code
+                "123123"
             )
 
-            await expect(result).rejects.toThrow("already exists")
+            await expect(fun).rejects.toThrow("already exists")
         })
     })
 
     describe("# isGroupMember", () => {
-        it("Should return false if a member does not exist", async () => {
-            const result = await groupsService.isGroupMember("Group1", "123122")
+        it("Should return false if a member does not exist", () => {
+            const result = groupsService.isGroupMember("Group1", "123122")
 
             expect(result).toBeFalsy()
         })
 
-        it("Should return true if a member exists", async () => {
-            const result = await groupsService.isGroupMember("Group1", "123123")
+        it("Should return true if a member exists", () => {
+            const result = groupsService.isGroupMember("Group1", "123123")
 
             expect(result).toBeTruthy()
         })
     })
 
     describe("# generateMerkleProof", () => {
-        it("Should return a Merkle proof", async () => {
-            const merkleproof = await groupsService.generateMerkleProof(
+        it("Should return a Merkle proof", () => {
+            const merkleproof = groupsService.generateMerkleProof(
                 "Group1",
                 "123123"
             )
@@ -174,9 +174,10 @@ describe("GroupsService", () => {
         })
 
         it("Should not return any Merkle proof if the member does not exist", async () => {
-            const result = groupsService.generateMerkleProof("Group1", "123122")
+            const fun = () =>
+                groupsService.generateMerkleProof("Group1", "123122")
 
-            await expect(result).rejects.toThrow("does not exist")
+            expect(fun).toThrow("does not exist")
         })
     })
 })

--- a/apps/api/src/app/invites/invites.service.spec.ts
+++ b/apps/api/src/app/invites/invites.service.spec.ts
@@ -55,12 +55,12 @@ describe("InvitesService", () => {
         })
 
         it("Should not create an invite if the admin is the wrong one", async () => {
-            const result = invitesService.createInvite(
+            const fun = invitesService.createInvite(
                 { groupName: "Group1" },
                 "wrong-admin"
             )
 
-            await expect(result).rejects.toThrow("No permissions")
+            await expect(fun).rejects.toThrow("No permissions")
         })
     })
 
@@ -81,9 +81,9 @@ describe("InvitesService", () => {
         })
 
         it("Should not redeem an invite if it has already been redeemed", async () => {
-            const result = invitesService.redeemInvite(invite.code)
+            const fun = invitesService.redeemInvite(invite.code)
 
-            await expect(result).rejects.toThrow("has already been redeemed")
+            await expect(fun).rejects.toThrow("has already been redeemed")
         })
     })
 

--- a/apps/api/src/app/invites/invites.service.ts
+++ b/apps/api/src/app/invites/invites.service.ts
@@ -28,14 +28,14 @@ export class InvitesService {
      * @returns The created invite.
      */
     async createInvite(
-        dto: CreateInviteDto,
+        { groupName }: CreateInviteDto,
         groupAdmin: string
     ): Promise<Invite> {
-        const group = await this.groupsService.getGroup(dto.groupName)
+        const group = await this.groupsService.getGroup(groupName)
 
         if (group.admin !== groupAdmin) {
             throw new UnauthorizedException(
-                `No permissions: You are not the admin of this group: {'${dto.groupName}'}.`
+                `No permissions: You are not the admin of this group: {'${groupName}'}.`
             )
         }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR makes some `GroupsService` functions and `groups` APIs faster by leveraging the cached groups saved in a JS map. Those groups are created with `@semaphore-protocol/group` in the service constructor, and create a Merkle tree for each DB group, that can be used to generate Merkle proofs. They can also be used by some functions, like `isGroupMember`, to avoid accessing data from the DB.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#41 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
