### PR TITLE
Update some API entity parameters 

### DIFF
--- a/apps/api/src/app/accounts/account.service.ts
+++ b/apps/api/src/app/accounts/account.service.ts
@@ -1,13 +1,8 @@
+import { id } from "@ethersproject/hash"
 import { Injectable } from "@nestjs/common"
 import { InjectRepository } from "@nestjs/typeorm"
-import {
-    DeleteResult,
-    FindOptionsWhere,
-    Repository,
-    UpdateResult
-} from "typeorm"
+import { FindOptionsWhere, Repository } from "typeorm"
 import { CreateAccountDTO } from "./dto/create-account.dto"
-import { UpdateAccountDTO } from "./dto/update-account.dto"
 import { Account } from "./entities/account.entity"
 
 @Injectable()
@@ -20,11 +15,9 @@ export class AccountService {
     public async create(
         payload: CreateAccountDTO
     ): Promise<Account & CreateAccountDTO> {
-        return this.accountRepository.save(payload)
-    }
+        payload.userId = BigInt(id(payload.userId)).toString()
 
-    public async findAll(): Promise<Account[]> {
-        return this.accountRepository.find()
+        return this.accountRepository.save(payload)
     }
 
     public async findOne(
@@ -33,14 +26,18 @@ export class AccountService {
         return this.accountRepository.findOneBy(payload)
     }
 
-    public async update(
-        id: number,
-        payload: UpdateAccountDTO
-    ): Promise<UpdateResult> {
-        return this.accountRepository.update(id, payload)
-    }
+    //public async findAll(): Promise<Account[]> {
+    //return this.accountRepository.find()
+    //}
 
-    public async remove(id: number): Promise<DeleteResult> {
-        return this.accountRepository.delete(id)
-    }
+    //public async update(
+    //id: number,
+    //payload: UpdateAccountDTO
+    //): Promise<UpdateResult> {
+    //return this.accountRepository.update(id, payload)
+    //}
+
+    //public async remove(id: number): Promise<DeleteResult> {
+    //return this.accountRepository.delete(id)
+    //}
 }

--- a/apps/api/src/app/accounts/entities/account.entity.ts
+++ b/apps/api/src/app/accounts/entities/account.entity.ts
@@ -2,6 +2,7 @@ import {
     Column,
     CreateDateColumn,
     Entity,
+    Index,
     PrimaryGeneratedColumn
 } from "typeorm"
 import { ServiceType } from "../../auth/types"
@@ -24,6 +25,7 @@ export class Account {
     refreshToken?: string
 
     @Column()
+    @Index({ unique: true })
     username: string
 
     @Column({ nullable: true })

--- a/apps/api/src/app/common/utils.ts
+++ b/apps/api/src/app/common/utils.ts
@@ -1,3 +1,5 @@
+import { ObjectLiteral } from "typeorm"
+
 /**
  * Returns the string of a JSON, even if it contains bigint types.
  * @param obj JavaScript object.
@@ -7,4 +9,17 @@ export function stringifyJSON(obj: Record<string, unknown>): string {
     return JSON.stringify(obj, (_, v) =>
         typeof v === "bigint" ? v.toString() : v
     )
+}
+
+/**
+ * Returns an entity without internal DB parameters.
+ * @param entity Entity object.
+ * @returns Entity without internal parameters.
+ */
+export function mapEntity<Entity extends ObjectLiteral>(
+    entity: Entity
+): Omit<Entity, "id"> {
+    delete entity.id
+
+    return entity
 }

--- a/apps/api/src/app/groups/groups.controller.ts
+++ b/apps/api/src/app/groups/groups.controller.ts
@@ -9,7 +9,7 @@ import {
     UseGuards
 } from "@nestjs/common"
 import { AuthGuard } from "@nestjs/passport"
-import { stringifyJSON } from "../common/utils"
+import { mapEntity, stringifyJSON } from "../common/utils"
 import { AddMemberDto } from "./dto/add-member.dto"
 import { CreateGroupDto } from "./dto/create-group.dto"
 import { UpdateGroupDto } from "./dto/update-group.dto"
@@ -21,31 +21,37 @@ export class GroupsController {
     constructor(private readonly groupsService: GroupsService) {}
 
     @Get()
-    getAllGroups(): Promise<Group[]> {
-        return this.groupsService.getAllGroups()
+    async getAllGroups(): Promise<Omit<Group, "id">[]> {
+        const groups = await this.groupsService.getAllGroups()
+
+        return groups.map(mapEntity)
     }
 
     @Post()
     @UseGuards(AuthGuard("jwt"))
-    createGroup(
+    async createGroup(
         @Req() req: Request,
         @Body() dto: CreateGroupDto
-    ): Promise<Group> {
-        return this.groupsService.createGroup(dto, req["user"].userId)
+    ): Promise<Omit<Group, "id">> {
+        const group = this.groupsService.createGroup(dto, req["user"].userId)
+
+        return mapEntity(group)
     }
 
     @Put(":name")
     @UseGuards(AuthGuard("jwt"))
-    updateGroup(
+    async updateGroup(
         @Req() req: Request,
         @Param("name") groupName: string,
         @Body() dto: UpdateGroupDto
-    ): Promise<Group> {
-        return this.groupsService.updateGroup(
+    ): Promise<Omit<Group, "id">> {
+        const group = await this.groupsService.updateGroup(
             dto,
             groupName,
             req["user"].userId
         )
+
+        return group
     }
 
     @Post(":name/:member")
@@ -59,13 +65,21 @@ export class GroupsController {
 
     @Get("admin-groups")
     @UseGuards(AuthGuard("jwt"))
-    getGroupsByAdmin(@Req() req: Request): Promise<Group[]> {
-        return this.groupsService.getGroupsByAdmin(req["user"].userId)
+    async getGroupsByAdmin(@Req() req: Request): Promise<Omit<Group, "id">[]> {
+        const groups = await this.groupsService.getGroupsByAdmin(
+            req["user"].userId
+        )
+
+        return groups.map(mapEntity)
     }
 
     @Get(":name")
-    getGroup(@Param("name") groupName: string): Promise<Group> {
-        return this.groupsService.getGroup(groupName)
+    async getGroup(
+        @Param("name") groupName: string
+    ): Promise<Omit<Group, "id">> {
+        const group = await this.groupsService.getGroup(groupName)
+
+        return mapEntity(group)
     }
 
     @Get(":name/:member")

--- a/apps/api/src/app/groups/groups.controller.ts
+++ b/apps/api/src/app/groups/groups.controller.ts
@@ -33,7 +33,7 @@ export class GroupsController {
         @Req() req: Request,
         @Body() dto: CreateGroupDto
     ): Promise<Omit<Group, "id">> {
-        const group = this.groupsService.createGroup(dto, req["user"].userId)
+        const group = this.groupsService.createGroup(dto, req["user"].username)
 
         return mapEntity(group)
     }
@@ -48,7 +48,7 @@ export class GroupsController {
         const group = await this.groupsService.updateGroup(
             dto,
             groupName,
-            req["user"].userId
+            req["user"].username
         )
 
         return group
@@ -67,7 +67,7 @@ export class GroupsController {
     @UseGuards(AuthGuard("jwt"))
     async getGroupsByAdmin(@Req() req: Request): Promise<Omit<Group, "id">[]> {
         const groups = await this.groupsService.getGroupsByAdmin(
-            req["user"].userId
+            req["user"].username
         )
 
         return groups.map(mapEntity)

--- a/apps/api/src/app/groups/groups.service.ts
+++ b/apps/api/src/app/groups/groups.service.ts
@@ -92,7 +92,7 @@ export class GroupsService {
     /**
      * Creates a new group.
      * @param dto External parameters used to create a new group.
-     * @param admin Admin id from jwt auth.
+     * @param admin Admin username.
      * @returns Created group.
      */
     async createGroup(
@@ -123,7 +123,7 @@ export class GroupsService {
      * Updates some parameters of the group.
      * @param dto External parameters used to update a group.
      * @param groupName Group name.
-     * @param admin Admin id from jwt auth.
+     * @param admin Admin username.
      * @returns Updated group.
      */
     async updateGroup(
@@ -207,7 +207,7 @@ export class GroupsService {
 
     /**
      * Returns a list of groups of a specific admin.
-     * @param admin Admin id from jwt auth.
+     * @param admin Admin username.
      * @returns List of admin's existing groups.
      */
     async getGroupsByAdmin(admin: string): Promise<Group[]> {

--- a/apps/api/src/app/invites/invites.controller.ts
+++ b/apps/api/src/app/invites/invites.controller.ts
@@ -25,7 +25,7 @@ export class InvitesController {
     ): Promise<string> {
         const { code } = await this.invitesService.createInvite(
             dto,
-            req["user"].userId
+            req["user"].username
         )
 
         return code

--- a/apps/api/src/app/invites/invites.controller.ts
+++ b/apps/api/src/app/invites/invites.controller.ts
@@ -8,6 +8,7 @@ import {
     UseGuards
 } from "@nestjs/common"
 import { AuthGuard } from "@nestjs/passport"
+import { mapEntity } from "../common/utils"
 import { CreateInviteDto } from "./dto/create-invite.dto"
 import { Invite } from "./entities/invite.entity"
 import { InvitesService } from "./invites.service"
@@ -31,7 +32,13 @@ export class InvitesController {
     }
 
     @Get(":code")
-    async getInvite(@Param("code") inviteCode: string): Promise<Invite> {
-        return this.invitesService.getInvite(inviteCode)
+    async getInvite(
+        @Param("code") inviteCode: string
+    ): Promise<Omit<Invite, "id">> {
+        const invite = (await this.invitesService.getInvite(inviteCode)) as any
+
+        invite.group = invite.group.name
+
+        return mapEntity(invite)
     }
 }

--- a/apps/api/src/app/invites/invites.service.ts
+++ b/apps/api/src/app/invites/invites.service.ts
@@ -57,7 +57,7 @@ export class InvitesService {
      * @param inviteCode Invite code.
      * @returns The invite data.
      */
-    async getInvite(inviteCode: string): Promise<any> {
+    async getInvite(inviteCode: string): Promise<Invite> {
         const invite = await this.inviteRepository.findOne({
             where: {
                 code: inviteCode

--- a/apps/api/src/app/invites/invites.service.ts
+++ b/apps/api/src/app/invites/invites.service.ts
@@ -25,7 +25,7 @@ export class InvitesService {
      * Creates a new group invite with a unique code. Group invites can only be
      * created by group admins.
      * @param dto External parameters used to create a new Invite.
-     * @param groupAdmin Group admin.
+     * @param groupAdmin Group admin username.
      * @returns The created invite.
      */
     async createInvite(

--- a/apps/client/src/pages/permissioned-group.tsx
+++ b/apps/client/src/pages/permissioned-group.tsx
@@ -20,7 +20,7 @@ export default function PermissionedGroup(): JSX.Element {
             const invite = await getInvite(inviteCode)
 
             if (invite) {
-                setGroupName(invite.group.name)
+                setGroupName(invite.group)
                 setIsRedeemed(invite.redeemed)
             }
         })()
@@ -40,6 +40,7 @@ export default function PermissionedGroup(): JSX.Element {
                 _signer &&
                 _groupName &&
                 (await generateIdentityCommitment(_signer, _groupName))
+
             if (hasjoined) {
                 alert("You have already joined")
                 return

--- a/apps/client/src/types/invite.ts
+++ b/apps/client/src/types/invite.ts
@@ -1,8 +1,7 @@
 import { Group } from "./group"
 
 export type Invite = {
-    _id: string
     code: string
     redeemed: boolean
-    group: Group
+    group: string
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR removes the `id` parameter from the entities which are shared externally with the APIs, since it is just used internally to manage DB entities. It also lets groups use the admin username rather than the admin id, and it hashes the admin `userId` parameter.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#54, #71

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
